### PR TITLE
Fix trailing dot helper

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -532,14 +532,14 @@ ReplaceSpecialCharacters <- function(string = "obj@meta$alpha[[3]]", replacement
 
 #' @title AddTrailingDotIfNonePresent
 #'
-#' @description Adds a final slash '/', if missing from a string (file path).
-#' @param string The file path potentially missing the trailing slash
+#' @description Adds a final dot '.', if missing from a string (file path).
+#' @param string The file path potentially missing the trailing dot
 #' @examples AddTrailingDotIfNonePresent(string = "stairway.to.heaven")
 #'
 #' @export
 AddTrailingDotIfNonePresent <- function(string = "stairway.to.heaven") {
   LastChr <- substr(string, nchar(string), nchar(string))
-  if (!LastChr == "\\.") {
+  if (LastChr != ".") {
     string <- paste0(string, ".")
   }
   return(string)

--- a/man/AddTrailingDotIfNonePresent.Rd
+++ b/man/AddTrailingDotIfNonePresent.Rd
@@ -7,10 +7,10 @@
 AddTrailingDotIfNonePresent(string = "stairway.to.heaven")
 }
 \arguments{
-\item{string}{The file path potentially missing the trailing slash}
+\item{string}{The file path potentially missing the trailing dot}
 }
 \description{
-Adds a final slash '/', if missing from a string (file path).
+Adds a final dot '.', if missing from a string (file path).
 }
 \examples{
 AddTrailingDotIfNonePresent(string = "stairway.to.heaven")


### PR DESCRIPTION
## Summary
- Correct logic in `AddTrailingDotIfNonePresent` so that it only appends a dot when missing
- Update documentation for `AddTrailingDotIfNonePresent`

## Testing
- `R CMD check .` *(fails: Required field missing or empty: 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_6890fca8fa9c832c9b49292b3aa9cf1b