### PR TITLE
fix ReplaceRepeatedUnderscores documentation

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -452,10 +452,10 @@ RemoveFinalSlash <- function(string) {
 # _________________________________________________________________________________________________
 #' @title ReplaceRepeatedUnderscores
 #'
-#' @description ReplaceRepeatedUnderscores replaces multiple consecutive slashes with a single slash.
-#' @param string The string (file path) potentially having repeated slashes.
-#' @examples ReplaceRepeatedUnderscores(string = "path//to//folder")
-#' @return A string with repeated slashes replaced by a single slash.
+#' @description ReplaceRepeatedUnderscores replaces multiple consecutive underscores with a single underscore.
+#' @param string The string (file path) potentially having repeated underscores.
+#' @examples ReplaceRepeatedUnderscores(string = "path__to__folder")
+#' @return A string with repeated underscores replaced by a single underscore.
 #' @export
 ReplaceRepeatedUnderscores <- function(string) {
   gsub(pattern = "_+", replacement = "_", x = string)

--- a/man/ReplaceRepeatedUnderscores.Rd
+++ b/man/ReplaceRepeatedUnderscores.Rd
@@ -7,14 +7,14 @@
 ReplaceRepeatedUnderscores(string)
 }
 \arguments{
-\item{string}{The string (file path) potentially having repeated slashes.}
+\item{string}{The string (file path) potentially having repeated underscores.}
 }
 \value{
-A string with repeated slashes replaced by a single slash.
+A string with repeated underscores replaced by a single underscore.
 }
 \description{
-ReplaceRepeatedUnderscores replaces multiple consecutive slashes with a single slash.
+ReplaceRepeatedUnderscores replaces multiple consecutive underscores with a single underscore.
 }
 \examples{
-ReplaceRepeatedUnderscores(string = "path//to//folder")
+ReplaceRepeatedUnderscores(string = "path__to__folder")
 }


### PR DESCRIPTION
## Summary
- Clarify that `ReplaceRepeatedUnderscores` collapses repeated underscores and show `"path__to__folder"` example

## Testing
- `R -q -e "devtools::document()"` *(fails: there is no package called ‘devtools’)*
- `R CMD check .` *(fails: Required field missing or empty: ‘Maintainer’)*

------
https://chatgpt.com/codex/tasks/task_e_68913716497c832c9a31719b57e1b4b2