### PR TITLE
Fix parameter spelling in percentile2value docs

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -868,7 +868,7 @@ pad.na <- function(x, len) {
 
 #' @title percentile2value
 #' @description Calculate what is the actual value of the N-th percentile in a distribution or set of numbers.
-#' Useful for calculating cutoffs, and displaying them by whist()s "vline" paramter.
+#' Useful for calculating cutoffs, and displaying them by whist()s "vline" parameter.
 #' @param distribution A numeric vector
 #' @param percentile percentile, Default: 0.95
 #' @param FirstValOverPercentile PARAM_DESCRIPTION, Default: TRUE

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Simplified Paste by fwd slash. Simplified Paste by fwd slash
 Simplified Paste by underscore. Simplified Paste by underscore
 
 - #### 40 `percentile2value()`
-percentile2value. Calculate what is the actual value of the N-th percentile in a distribution or set of numbers.  Useful for calculating cutoffs, and displaying them by whist()s "vline" paramter.
+percentile2value. Calculate what is the actual value of the N-th percentile in a distribution or set of numbers.  Useful for calculating cutoffs, and displaying them by whist()s "vline" parameter.
 
 - #### 41 `parsepvalue()`
 parsepvalue. Parse p-value from a number to a string.

--- a/man/percentile2value.Rd
+++ b/man/percentile2value.Rd
@@ -19,5 +19,5 @@ percentile2value(
 }
 \description{
 Calculate what is the actual value of the N-th percentile in a distribution or set of numbers.
-Useful for calculating cutoffs, and displaying them by whist()s "vline" paramter.
+Useful for calculating cutoffs, and displaying them by whist()s "vline" parameter.
 }


### PR DESCRIPTION
## Summary
- Correct spelling of parameter in `percentile2value` documentation and README.
- Update generated man page accordingly.

## Testing
- `R -q -e 'devtools::document()'` *(fails: package 'devtools' not installed)*
- `R -q -e 'install.packages("devtools", repos="https://cloud.r-project.org")'` *(fails: 403 from proxy)*
- `apt-get install -y r-cran-devtools` *(aborted: would download 807 MB of packages)*
- `R CMD check --no-manual --as-cran .` *(fails: Required field 'Maintainer' missing in DESCRIPTION)*

------
https://chatgpt.com/codex/tasks/task_e_6891368c7344832c88b19ebe650edc9f