### PR TITLE
Add dplyr and stringr to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,9 +10,11 @@ License: GPL-3 + file LICENSE
 BugReports: https://github.com/vertesy/Stringendo/issues
 Depends: 
     base
-Imports: 
-    clipr
-Suggests: 
+Imports:
+    clipr,
+    dplyr,
+    stringr
+Suggests:
     MarkdownHelpers,
     MarkdownReports
 Encoding: UTF-8


### PR DESCRIPTION
## Summary
- Declare `dplyr` and `stringr` under Imports in `DESCRIPTION`.

## Testing
- `R -q -e 'devtools::document()'` *(fails: there is no package called ‘devtools’)*

------
https://chatgpt.com/codex/tasks/task_e_689137f8ce40832c91fd86c0f30c03c1