### PR TITLE
docs: improve idate documentation

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -337,11 +337,23 @@ iprint <- function(...) {
 # _________________________________________________________________________________________________
 #' @title Parse current date, dot separated.
 #'
+#' @description
+#' Returns the current system date and time formatted as a character
+#' string. The default format uses dot separated components, but any
+#' format recognised by [base::format] can be supplied.
+#' 
 #' @param Format Date format. Default: c("%Y.%m.%d_%H.%M", "%Y.%m.%d_%Hh")[2]
+#'
+#' @return A character string of the current date/time formatted according
+#'   to `Format`.
+#'
+#' @examples
+#' idate()
+#' idate("%Y-%m-%d")
 #' @export
 
 idate <- function(Format = c("%Y.%m.%d_%H.%M", "%Y.%m.%d_%Hh")[2]) {
-  format(Sys.time(), format = Format)
+  return(format(Sys.time(), format = Format))
 }
 
 

--- a/man/idate.Rd
+++ b/man/idate.Rd
@@ -7,8 +7,15 @@
 idate(Format = c("\%Y.\%m.\%d_\%H.\%M", "\%Y.\%m.\%d_\%Hh")[2])
 }
 \arguments{
-\item{Format}{Date format. Default: c("\%Y.\%m.\%d_\%H.\%M", "\%Y.\%m.\%d_\%Hh")\link{2}}
+\item{Format}{Date format. Default: c("\%Y.\%m.\%d_\%H.\%M", "\%Y.\%m.\%d_\%Hh")[2]}
+}
+\value{
+A character string of the current date/time formatted according to \code{Format}.
 }
 \description{
-Parse current date, dot separated.
+Returns the current system date and time formatted as a character string.
+}
+\examples{
+idate()
+idate("%Y-%m-%d")
 }


### PR DESCRIPTION
## Summary
- clarify formatted date string returned by `idate`
- document return value and examples
- note explicit return statement in `idate`

## Testing
- `R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*
- `R -q -e "install.packages('devtools', repos='https://cloud.r-project.org')"` *(fails: package 'devtools' is not available)*
- `R -q -e "source('R/Stringendo.R'); idate(); idate('%Y-%m-%d')"`

------
https://chatgpt.com/codex/tasks/task_e_68913c9f45c4832ca7d82e9864ed993f