### PR TITLE
Clarify collapse parameter wording

### DIFF
--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -18,7 +18,7 @@
 # ______________________________________________________________________________________________________________________________
 #' @title iprint
 #' @description A more intelligent printing function that collapses any variable passed to it by white spaces.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Values to collapse consecutively with spaces.
 #' @examples iprint("Hello ", "you ", 3, ", ", 11, " year old kids.")
 #' @export
 
@@ -285,7 +285,7 @@ kppd <- function(...) {
 #'
 #' @description Collapses values and strings to one string (without a white space).
 #' It also prints the results (good for a quick check)
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Values to collapse consecutively without spaces.
 #' @param collapseby collapse elements into a string separated by this character
 #' @param print Print the results to the terminal. TRUE by default.
 #' @examples kollapse(

--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -310,9 +310,9 @@ message2 <- function(vec) for (item in vec) message(item)
 # ______________________________________________________________________________________________________________________________
 #' @title imessage
 #' @description A variant to message() pasting with white space, sibling of iprint().
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Values to collapse consecutively with spaces.
 #' @param collapse Separator to be used for collapsing. Default: " "
-#'
+#' 
 #' @examples iprint("Hello ", "you ", 3, ", ", 11, " year old kids.")
 #' @export
 
@@ -325,7 +325,7 @@ imessage <- function(..., collapse = " ") {
 # ______________________________________________________________________________________________________________________________
 #' @title iprint
 #' @description A more intelligent printing function that collapses any variable passed to it by white spaces.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Values to collapse consecutively with spaces.
 #' @examples iprint("Hello ", "you ", 3, ", ", 11, " year old kids.")
 #' @export
 
@@ -759,7 +759,7 @@ kpwNames <- function(x = c("a" = 1, "b" = 2), sep1 = ": ", sep2 = " | ", prefix 
 #'
 #' @description Collapses values and strings to one string (without a white space).
 #' It also prints the results (good for a quick check)
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Values to collapse consecutively without spaces.
 #' @param collapseby collapse elements into a string separated by this character
 #' @param print Print the results to the terminal. Default is 1 for `print()`.
 #' Set to 2 for `message()`.

--- a/man/imessage.Rd
+++ b/man/imessage.Rd
@@ -7,7 +7,7 @@
 imessage(..., collapse = " ")
 }
 \arguments{
-\item{...}{Variables (strings, vectors) to be collapsed in consecutively.}
+\item{...}{Values to collapse consecutively with spaces.}
 
 \item{collapse}{Separator to be used for collapsing. Default: " "}
 }

--- a/man/iprint.Rd
+++ b/man/iprint.Rd
@@ -7,7 +7,7 @@
 iprint(...)
 }
 \arguments{
-\item{...}{Variables (strings, vectors) to be collapsed in consecutively.}
+\item{...}{Values to collapse consecutively with spaces.}
 }
 \description{
 A more intelligent printing function that collapses any variable passed to it by white spaces.

--- a/man/kollapse.Rd
+++ b/man/kollapse.Rd
@@ -7,7 +7,7 @@
 kollapse(..., collapseby = "", print = 1)
 }
 \arguments{
-\item{...}{Variables (strings, vectors) to be collapsed in consecutively.}
+\item{...}{Values to collapse consecutively without spaces.}
 
 \item{collapseby}{collapse elements into a string separated by this character}
 


### PR DESCRIPTION
## Summary
- Clarify `...` parameter descriptions for `imessage`, `iprint`, and `kollapse` so that ellipsis values are described as being collapsed consecutively with or without spaces.
- Regenerate Rd documentation for these helpers.

## Testing
- `R CMD check --no-manual --no-build-vignettes .` *(fails: Required field missing or empty: 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_68913ca5bbdc832ca650000b9e2d0d3e