### PR TITLE
Document separators for helper paste functions

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -639,7 +639,7 @@ pnl <- function(...) {
 # Collapse (and paste) -----------------------------------------------------------------------
 
 #' @title Collapse and paste by point
-#' @description Collapse by point
+#' @description Collapse by period (`.`)
 #' @param ... Multiple simple variables to parse.
 #' @examples kpp("A", 1:2, "end")
 #' @export
@@ -649,7 +649,7 @@ kpp <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by underscore
-#' @description Collapse by underscore
+#' @description Collapse by underscore (`_`)
 #' @param ... Multiple simple variables to parse.
 #' @examples kppu("A", 1:2, "end")
 #' @export
@@ -659,7 +659,7 @@ kppu <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by (forward) slash
-#' @description Collapse by (forward) slash
+#' @description Collapse by forward slash (`/`)
 #' @param ... Multiple simple variables to parse.
 #' @examples kpps("A", 1:2, "end")
 #' @export
@@ -670,7 +670,7 @@ kpps <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by dash
-#' @description Collapse by dash
+#' @description Collapse by dash (`-`)
 #' @param ... Multiple simple variables to parse.
 #' @examples kppd("A", 1:2, "end")
 #' @export
@@ -680,7 +680,7 @@ kppd <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by white space
-#' @description Collapse by white space
+#' @description Collapse by white space (` `)
 #' @param ... Multiple simple variables to parse.
 #' @examples kppws("A", 1:2, "end")
 #' @export
@@ -691,7 +691,7 @@ kppws <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by comma (and white space)
-#' @description Collapse by white space
+#' @description Collapse by comma and white space (`, `)
 #' @param ... Multiple simple variables to parse.
 #' @examples kppc("A", 1:2, "end")
 #' @export
@@ -701,7 +701,7 @@ kppc <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by pipe (|) and white spaces around it
-#' @description Collapse by white space
+#' @description Collapse by pipe (`|`) with surrounding spaces
 #' @param ... Multiple simple variables to parse.
 #' @examples kpipe("A", 1:2, "end")
 #' @export
@@ -711,7 +711,7 @@ kpipe <- function(...) {
 
 # _________________________________________________________________________________________________
 #' @title Collapse and paste by newline (`\n`) preceded by a white space
-#' @description Collapse by white space
+#' @description Collapse by newline (`\n`) preceded by a white space
 #' @param ... Multiple simple variables to parse.
 #' @examples knl("A", 1:2, "end")
 #' @export

--- a/man/knl.Rd
+++ b/man/knl.Rd
@@ -10,7 +10,7 @@ knl(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by white space
+Collapse by newline (\verb{\\n}) preceded by a white space
 }
 \examples{
 knl("A", 1:2, "end")

--- a/man/kpipe.Rd
+++ b/man/kpipe.Rd
@@ -10,7 +10,7 @@ kpipe(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by white space
+Collapse by pipe (\code{|}) with surrounding spaces
 }
 \examples{
 kpipe("A", 1:2, "end")

--- a/man/kpp.Rd
+++ b/man/kpp.Rd
@@ -10,7 +10,7 @@ kpp(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by point
+Collapse by period (\code{.})
 }
 \examples{
 kpp("A", 1:2, "end")

--- a/man/kppc.Rd
+++ b/man/kppc.Rd
@@ -10,7 +10,7 @@ kppc(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by white space
+Collapse by comma and white space (\verb{, })
 }
 \examples{
 kppc("A", 1:2, "end")

--- a/man/kppd.Rd
+++ b/man/kppd.Rd
@@ -10,7 +10,7 @@ kppd(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by dash
+Collapse by dash (\code{-})
 }
 \examples{
 kppd("A", 1:2, "end")

--- a/man/kpps.Rd
+++ b/man/kpps.Rd
@@ -10,7 +10,7 @@ kpps(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by (forward) slash
+Collapse by forward slash (\code{/})
 }
 \examples{
 kpps("A", 1:2, "end")

--- a/man/kppu.Rd
+++ b/man/kppu.Rd
@@ -10,7 +10,7 @@ kppu(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by underscore
+Collapse by underscore (\verb{_})
 }
 \examples{
 kppu("A", 1:2, "end")

--- a/man/kppws.Rd
+++ b/man/kppws.Rd
@@ -10,7 +10,7 @@ kppws(...)
 \item{...}{Multiple simple variables to parse.}
 }
 \description{
-Collapse by white space
+Collapse by white space (\verb{ })
 }
 \examples{
 kppws("A", 1:2, "end")


### PR DESCRIPTION
## Summary
- clarify separator descriptions for kpp*, kpipe, and knl helpers
- regenerate Rd documentation

## Testing
- `Rscript -e 'roxygen2::roxygenise()'`
- `R CMD check .` *(fails: Required field missing or empty: 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_6891a7d3e1d8832c9f60493f5d2532ec