### PR TITLE
docs: remove default param from testNumericCompatible

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -240,7 +240,7 @@ is.numeric.or.logical <- function(x) {
 #' can be converted to a numeric value without loss of information and is not inherently a
 #' character string, otherwise it returns FALSE.
 #'
-#' @param x The variable to be tested. Default: NA.
+#' @param x The variable to be tested.
 #'
 #' @return A logical value indicating whether the input is inherently numeric.
 #'

--- a/man/testNumericCompatible.Rd
+++ b/man/testNumericCompatible.Rd
@@ -7,7 +7,7 @@
 testNumericCompatible(x)
 }
 \arguments{
-\item{x}{The variable to be tested. Default: NA.}
+\item{x}{The variable to be tested.}
 }
 \value{
 A logical value indicating whether the input is inherently numeric.


### PR DESCRIPTION
## Summary
- remove mention of default value for `x` in `testNumericCompatible()`
- regenerate `testNumericCompatible` documentation

## Testing
- `R CMD check .` *(fails: cannot access CRAN repository)*

------
https://chatgpt.com/codex/tasks/task_e_6891c0e7ef2c832c9a8a35cad1f68886