### PR TITLE
Clarify percentile2value parameter docs

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -887,7 +887,8 @@ pad.na <- function(x, len) {
 #' Useful for calculating cutoffs, and displaying them by whist()s "vline" parameter.
 #' @param distribution A numeric vector
 #' @param percentile percentile, Default: 0.95
-#' @param FirstValOverPercentile PARAM_DESCRIPTION, Default: TRUE
+#' @param FirstValOverPercentile Whether to return the first value at or above the
+#'   percentile (TRUE) or the value just below it (FALSE), Default: TRUE
 #' @export
 
 

--- a/man/percentile2value.Rd
+++ b/man/percentile2value.Rd
@@ -15,7 +15,8 @@ percentile2value(
 
 \item{percentile}{percentile, Default: 0.95}
 
-\item{FirstValOverPercentile}{PARAM_DESCRIPTION, Default: TRUE}
+\item{FirstValOverPercentile}{Whether to return the first value at or above the
+percentile (TRUE) or the value just below it (FALSE), Default: TRUE}
 }
 \description{
 Calculate what is the actual value of the N-th percentile in a distribution or set of numbers.


### PR DESCRIPTION
## Summary
- Clarify `FirstValOverPercentile` parameter to explain how percentile thresholds are interpreted.
- Regenerate `percentile2value` documentation from updated roxygen comments.

## Testing
- `R -q -e "roxygen2::roxygenise()"`
- `R -q -e "devtools::test()"` *(fails: `percentage_formatter` NA/NaN handling)*

------
https://chatgpt.com/codex/tasks/task_e_6891c215af48832cb466c71324d7c1cf