### PR TITLE
Refine clipboard dependency handling in toCamelCase

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -1036,7 +1036,7 @@ toCamelCase <- function(input_string,
   words[-1] <- sapply(words[-1], function(word) {
     paste0(toupper(substr(word, 1, 1)), tolower(substr(word, 2, nchar(word))))
   })
-  if (toclipboard & require(clipr)) try(clipr::write_clip(words), silent = TRUE)
+  if (toclipboard && requireNamespace("clipr", quietly = TRUE)) try(clipr::write_clip(words), silent = TRUE)
 
   # Concatenate the words back together
   return(paste0(words, collapse = ""))


### PR DESCRIPTION
## Summary
- Avoid loading clipr unnecessarily by using `requireNamespace('clipr', quietly = TRUE)` in `toCamelCase`
- Guard clipboard writes with `&&` to prevent side effects when the package is absent

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: could not find function `percentage_formatter`)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ba3a8a8832c85d61ce0d81c8479