### PR TITLE
Stop automatic package version bumps in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Guidance for Agents
 
-Version: 2026.08.27-00:00
+Version: 2026.08.30-00:00
 
 ## I: Generic (all @vertesy repos)
 
@@ -41,7 +41,8 @@ Package rebuilds overwrite these files, so always update the upstream source fir
 
 - New arguments go at the end, just before `...`. Never insert in the middle.
 - **Do not use tests!**
-- Whenever you are implementing a larger change (a bug fix, a substantial code change), you shoud increase the version number in `Development/config.R` by 0.0.1.
+- Never update the package version unless the user explicitly requests a version change.
+- Do not raise code review findings that ask for a package version change.
 
 ## III: Stringendo specific
 


### PR DESCRIPTION
### Motivation
- Remove the instruction to automatically bump package versions and stop code-review guidance that requests version changes so version updates happen only by explicit request.

### Description
- Update `AGENTS.md` (version updated to `2026.08.30-00:00`) and replace the automatic bump instruction with two lines: `Never update the package version unless the user explicitly requests a version change.` and `Do not raise code review findings that ask for a package version change.`

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a942e596200832c94b3954289836e9d)