### PR TITLE
Never auto-bump the package version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ Package rebuilds overwrite these files, so always update the upstream source fir
 
 - New arguments go at the end, just before `...`. Never insert in the middle.
 - **Do not use tests!**
-- Whenever you are implementing a larger change (a bug fix, a substantial code change), you shoud increase the version number in `Development/config.R` by 0.0.1.
+- Never update the package version unless the user explicitly requests a version change.
+- Do not raise code review findings that ask for a package version change.
 
 ## III: Stringendo specific
 


### PR DESCRIPTION
## Summary
Updates `AGENTS.md`: agents should never bump the package version on their own, and should not raise code-review findings asking for one.

## Why
Version bumps are now the user's explicit decision, not something to infer from change size.