### PR TITLE
Consolidate list-of-functions cleanup into one file.remove() call

### DIFF
--- a/Development/Create_the_Stringendo_Package.R
+++ b/Development/Create_the_Stringendo_Package.R
@@ -99,7 +99,8 @@ for (scriptX in ls.scripts.full.path) {
 }
 file.edit(paste0(repository.dir, "/R/list.of.functions.in.", package.name, ".det.md"))
 file.edit(paste0(repository.dir, "/README.md"))
-file.remove(paste0(repository.dir, "/R/list.of.functions.in.", package.name, ".det.md"))
+# file.remove(paste0(repository.dir, "/R/list.of.functions.in.", package.name, ".det.md"))
+file.remove(list.files(file.path(repository.dir, "R"), pattern = "^list\\.of\\.functions\\.in\\..+\\.det\\.md$", full.names = TRUE))
 
 r$PackageTools()
 PackageTools::copy_github_badge("active") # Add badge to readme via clipboard


### PR DESCRIPTION
- **What was wrong:** The dev build script removed the generated `list.of.functions.in.*.det.md` report with a hardcoded, single-file `file.remove()` line.
- **How it was fixed:** Replaced it with a `file.remove(list.files(..., pattern = "^list\\.of\\.functions\\.in\\..+\\.det\\.md$"))` call that matches any generated report by name. The old line is commented out, not deleted.
- **Behavior impact:** None — this is dev-only tooling, not exported/shipped code.