### PR TITLE
Fix parFlags2: use names(val) instead of undefined namez

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -1622,7 +1622,7 @@ parFlags2 <- function(prefix = ".",
     paste0(
       prefix,
       coll.char,
-      paste0(namez, coll.char.intra, val, collapse = coll.char)
+      paste0(names(val), coll.char.intra, val, collapse = coll.char)
     )
   }
   return(flg)


### PR DESCRIPTION
### Motivation
- parFlags2 used an undefined variable `namez` when building the pasted flag string, causing a runtime error; the intent is to interleave argument names and values from `...`.

### Description
- Replace the undefined `namez` with `names(val)` in `parFlags2` so the function uses the captured `...` names when pasting.
- Retain the original compact `stopifnot()` assertion and the existing line `names(val) <- as.character(match.call(expand.dots = FALSE)[["..."]])` that captures argument names.
- Regenerated `man/parFlags2.Rd` from the roxygen block (only documentation regen; function signature unchanged).

### Testing
- Ran `Rscript -e 'roxygen2::roxygenise(roclets = "rd")'` which produced a roxygen2 version warning but regenerated the Rd file.
- Ran the `parFlags2` example directly with `Rscript` and an inline `stopifnot()`; the example produced `MyPlot.pearson_1.filtered_3.normalized_0` and the assertion passed.
- Ran `R CMD check --no-tests --no-manual Stringendo_1.2.5.tar.gz`; the run failed due to an unrelated example error in `stopif()` and produced 2 warnings and 1 NOTE, so overall package check did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9819e36868832c877fcb1655d0febb)