### PR TITLE
Require explicit inputs for parameter flag helpers

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -1450,12 +1450,18 @@ params.2.fname <- function(..., sep = ".", collapse = "_") {
 # _________________________________________________________________________________________________
 #' @title param.list.2.fname
 #' @description Take a list of parameters and parse a string from their names and values.
-#' @param ls.of.params List of parameters, Default: p
+#' @param ls.of.params List of parameters.
 #' @param sep Separator name-2-value, Default: "."
 #' @param collapse Separator between elements, Default: "_"
 #'
+#' @examples
+#' parameters <- list(alpha = 1, beta = 2)
+#' param.list.2.fname(parameters)
+#'
 #' @export
-param.list.2.fname <- function(ls.of.params = p, sep = ".", collapse = "_") {
+param.list.2.fname <- function(ls.of.params, sep = ".", collapse = "_") {
+  stopifnot(is.list(ls.of.params), is.character(sep), length(sep) == 1, is.character(collapse), length(collapse) == 1)
+
   paste(names(ls.of.params), ls.of.params, sep = sep, collapse = collapse)
 }
 
@@ -1529,12 +1535,18 @@ flag.nameiftrue <- function(toggle, prefix = NULL, suffix = NULL, name.if.not = 
 # _________________________________________________________________________________________________
 #' @title flag.names_list
 #' @description Returns the name and value of each element in a list of parameters.
-#' @param ls List of parameters (name, value), Default: p.hm
+#' @param ls List of parameters (name, value).
 #' @param sep_name_val Separator name-2-value, Default: "_"
 #' @param sep_elem Separator between elements, Default: "-"
 #'
+#' @examples
+#' parameters <- list(method = "pearson", dimensions = 20)
+#' flag.names_list(parameters)
+#'
 #' @export
-flag.names_list <- function(ls = p.hm, sep_name_val = "_", sep_elem = "-") {
+flag.names_list <- function(ls, sep_name_val = "_", sep_elem = "-") {
+  stopifnot(is.list(ls), is.character(sep_name_val), length(sep_name_val) == 1, is.character(sep_elem), length(sep_elem) == 1)
+
   if (length(ls)) {
     paste(paste(names(ls), ls, sep = sep_name_val), collapse = sep_elem)
   }
@@ -1545,10 +1557,16 @@ flag.names_list.all.new <- function() .Deprecated("flag.names_list")
 # _________________________________________________________________________________________________
 #' @title param.list.flag
 #' @description Returns the name and value of each element in a list of parameters.
-#' @param par parameter, Default: p$umap.min_dist
+#' @param par Parameter value.
+#'
+#' @examples
+#' umap_min_dist <- 0.1
+#' param.list.flag(umap_min_dist)
 #'
 #' @export
-param.list.flag <- function(par = p$"umap.min_dist") {
+param.list.flag <- function(par) {
+  stopifnot(is.atomic(par), length(par) == 1)
+
   output <- paste(substitute(par), par, sep = "_")
   if (length(output) > 1) output <- output[length(output)] # fix for when input is a list element like p$'myparam'
   output

--- a/man/flag.names_list.Rd
+++ b/man/flag.names_list.Rd
@@ -4,10 +4,10 @@
 \alias{flag.names_list}
 \title{flag.names_list}
 \usage{
-flag.names_list(ls = p.hm, sep_name_val = "_", sep_elem = "-")
+flag.names_list(ls, sep_name_val = "_", sep_elem = "-")
 }
 \arguments{
-\item{ls}{List of parameters (name, value), Default: p.hm}
+\item{ls}{List of parameters (name, value).}
 
 \item{sep_name_val}{Separator name-2-value, Default: "_"}
 
@@ -15,4 +15,9 @@ flag.names_list(ls = p.hm, sep_name_val = "_", sep_elem = "-")
 }
 \description{
 Returns the name and value of each element in a list of parameters.
+}
+\examples{
+parameters <- list(method = "pearson", dimensions = 20)
+flag.names_list(parameters)
+
 }

--- a/man/param.list.2.fname.Rd
+++ b/man/param.list.2.fname.Rd
@@ -4,10 +4,10 @@
 \alias{param.list.2.fname}
 \title{param.list.2.fname}
 \usage{
-param.list.2.fname(ls.of.params = p, sep = ".", collapse = "_")
+param.list.2.fname(ls.of.params, sep = ".", collapse = "_")
 }
 \arguments{
-\item{ls.of.params}{List of parameters, Default: p}
+\item{ls.of.params}{List of parameters.}
 
 \item{sep}{Separator name-2-value, Default: "."}
 
@@ -15,4 +15,9 @@ param.list.2.fname(ls.of.params = p, sep = ".", collapse = "_")
 }
 \description{
 Take a list of parameters and parse a string from their names and values.
+}
+\examples{
+parameters <- list(alpha = 1, beta = 2)
+param.list.2.fname(parameters)
+
 }

--- a/man/param.list.flag.Rd
+++ b/man/param.list.flag.Rd
@@ -4,11 +4,16 @@
 \alias{param.list.flag}
 \title{param.list.flag}
 \usage{
-param.list.flag(par = p$umap.min_dist)
+param.list.flag(par)
 }
 \arguments{
-\item{par}{parameter, Default: p$umap.min_dist}
+\item{par}{Parameter value.}
 }
 \description{
 Returns the name and value of each element in a list of parameters.
+}
+\examples{
+umap_min_dist <- 0.1
+param.list.flag(umap_min_dist)
+
 }


### PR DESCRIPTION
### Motivation
- Remove implicit reliance on global helper objects (`p`, `p.hm`) so the three small helpers require explicit inputs. 
- Add compact base-run validations to fail early on incorrect argument types while preserving existing output for valid calls.

### Description
- Changed signatures: `param.list.2.fname(ls.of.params, ...)`, `flag.names_list(ls, ...)`, and `param.list.flag(par)` now require their main input instead of defaulting to `p`/`p.hm`/`p$...`.
- Added a single compact `stopifnot()` at the start of each function to validate key inputs using base predicates.
- Updated roxygen `@param` text for these three functions and added small runnable examples to each roxygen block.
- Regenerated `man/param.list.2.fname.Rd`, `man/flag.names_list.Rd`, and `man/param.list.flag.Rd` to reflect the API changes.

### Testing
- Ran `Rscript -e 'roxygen2::roxygenise(...)'` which wrote the three updated Rd files successfully.
- Built package and ran `R CMD check --no-tests --no-manual` on the source tarball; the run completed but returned other pre-existing issues: one ERROR (examples failure in `parFlags2` due to missing global `namez`), two WARNINGs (including `grapes-not-in-grapes.Rd`), and one NOTE (`parFlags2` undefined global).
- Confirmed that `R code for possible problems` no longer reports occurrences of `p` or `p.hm` (the targeted problem is resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a981a5c3128832c8982003d9f390ceb)