### PR TITLE
Wrap erroring `stopif()` examples in `try(..., silent = TRUE)` and regenerate Rd

### DIFF
--- a/R/Stringendo.R
+++ b/R/Stringendo.R
@@ -32,8 +32,8 @@
 #' @return The function stops execution if any condition evaluates to `TRUE`.
 #'
 #' @examples
-#' stopif(6 < 4, 6 > 5)
-#' stopif("custom message" = 6 > 5)
+#' try(stopif(6 < 4, 6 > 5), silent = TRUE)
+#' try(stopif("custom message" = 6 > 5), silent = TRUE)
 #'
 #' @export
 stopif <- function(...) {

--- a/man/stopif.Rd
+++ b/man/stopif.Rd
@@ -19,7 +19,7 @@ The \code{stopif()} function stops the execution if the condition is \code{TRUE}
 clarity in the code by removing double negations.
 }
 \examples{
-stopif(6 < 4, 6 > 5)
-stopif("custom message" = 6 > 5)
+try(stopif(6 < 4, 6 > 5), silent = TRUE)
+try(stopif("custom message" = 6 > 5), silent = TRUE)
 
 }


### PR DESCRIPTION
### Motivation
- The `stopif()` examples in the roxygen block executed as-is and intentionally raised errors, which breaks example execution and documentation generation, so wrap them in `try(..., silent = TRUE)` to preserve examples without changing function behavior.

### Description
- Replace example lines in `R/Stringendo.R` with `try(stopif(...), silent = TRUE)` and regenerate the documentation file `man/stopif.Rd` via roxygen, with no change to `stopif()` semantics.

### Testing
- Ran `Rscript -e 'roxygen2::roxygenise(".", roclets = "rd")'` which wrote `man/stopif.Rd` but emitted a roxygen2 version warning, and ran `git diff --check` and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98201e2e18832cb0a94490014f083b)